### PR TITLE
[#45] Assert count difference should take a prefix option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Added
 
-* Update `Repo.fetch_by`, `Repo.count`, and `Assertions.assert_count_difference` to take `opts` used for the repo query (eg: `prefix`). 
+* Give `Repo.fetch_by/2`, `Repo.count/1`, and `Assertions.assert_count_difference/4` an optional  `opts` parameter that is forwarded to the underlying Ecto function. Useful to pass query options like `:prefix`.
+
 ## [0.14.0] - 2023-01-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+### Added
+
+* Update `Repo.fetch_by`, `Repo.count`, and `Assertions.assert_count_difference` to take `opts` used for the repo query (eg: `prefix`). 
 ## [0.14.0] - 2023-01-03
 
 ### Added

--- a/lib/bitcrowd_ecto/assertions.ex
+++ b/lib/bitcrowd_ecto/assertions.ex
@@ -323,9 +323,11 @@ defmodule BitcrowdEcto.Assertions do
       end
   """
   @doc since: "0.1.0"
+  @spec assert_count_difference(Ecto.Repo.t(), module, integer, (() -> any)) ::
+          Changeset.t() | no_return
   @spec assert_count_difference(Ecto.Repo.t(), module, integer, (() -> any), keyword) ::
           Changeset.t() | no_return
-  def assert_count_difference(repo, schema, by, how, opts \\ []) when is_integer(by) do
+  def assert_count_difference(repo, schema, by, how, opts \\ []) do
     assert_difference(fn -> repo.count(schema, opts) end, by, how,
       message: "#{inspect(schema)} hasn't changed by #{by}"
     )
@@ -344,8 +346,11 @@ defmodule BitcrowdEcto.Assertions do
       end
   """
   @doc since: "0.1.0"
+  @spec assert_count_differences(Ecto.Repo.t(), [{module, integer}], (() -> any)) ::
+          Changeset.t() | no_return
   @spec assert_count_differences(Ecto.Repo.t(), [{module, integer}], (() -> any), keyword) ::
           Changeset.t() | no_return
+
   def assert_count_differences(repo, table_counts, how, opts \\ [])
   def assert_count_differences(_repo, [], how, _opts), do: how.()
 

--- a/lib/bitcrowd_ecto/assertions.ex
+++ b/lib/bitcrowd_ecto/assertions.ex
@@ -323,10 +323,10 @@ defmodule BitcrowdEcto.Assertions do
       end
   """
   @doc since: "0.1.0"
-  @spec assert_count_difference(Ecto.Repo.t(), module, integer, (() -> any)) ::
+  @spec assert_count_difference(Ecto.Repo.t(), module, integer, (() -> any), keyword) ::
           Changeset.t() | no_return
-  def assert_count_difference(repo, schema, by, how) do
-    assert_difference(fn -> repo.count(schema) end, by, how,
+  def assert_count_difference(repo, schema, by, how, opts \\ []) when is_integer(by) do
+    assert_difference(fn -> repo.count(schema, opts) end, by, how,
       message: "#{inspect(schema)} hasn't changed by #{by}"
     )
   end
@@ -334,7 +334,7 @@ defmodule BitcrowdEcto.Assertions do
   @doc """
   Assert multiple database table count changes.
 
-  See `assert_count_difference/4` for details.
+  See `assert_count_difference/5` for details.
 
   ## Example
 
@@ -344,14 +344,21 @@ defmodule BitcrowdEcto.Assertions do
       end
   """
   @doc since: "0.1.0"
-  @spec assert_count_differences(Ecto.Repo.t(), [{module, integer}], (() -> any)) ::
+  @spec assert_count_differences(Ecto.Repo.t(), [{module, integer}], (() -> any), keyword) ::
           Changeset.t() | no_return
-  def assert_count_differences(_repo, [], how), do: how.()
+  def assert_count_differences(repo, table_counts, how, opts \\ [])
+  def assert_count_differences(_repo, [], how, _opts), do: how.()
 
-  def assert_count_differences(repo, [{schema, by} | rest], how) do
-    assert_count_difference(repo, schema, by, fn ->
-      assert_count_differences(repo, rest, how)
-    end)
+  def assert_count_differences(repo, [{schema, by} | rest], how, opts) do
+    assert_count_difference(
+      repo,
+      schema,
+      by,
+      fn ->
+        assert_count_differences(repo, rest, how, opts)
+      end,
+      opts
+    )
   end
 
   @doc """

--- a/lib/bitcrowd_ecto/assertions.ex
+++ b/lib/bitcrowd_ecto/assertions.ex
@@ -325,7 +325,9 @@ defmodule BitcrowdEcto.Assertions do
   @doc since: "0.1.0"
   @spec assert_count_difference(Ecto.Repo.t(), module, integer, (() -> any)) ::
           Changeset.t() | no_return
-  @spec assert_count_difference(Ecto.Repo.t(), module, integer, (() -> any), keyword) ::
+  @spec assert_count_difference(Ecto.Repo.t(), module, integer, (() -> any), [
+          BitcrowdEcto.Repo.ecto_option()
+        ]) ::
           Changeset.t() | no_return
   def assert_count_difference(repo, schema, by, how, opts \\ []) do
     assert_difference(fn -> repo.count(schema, opts) end, by, how,

--- a/lib/bitcrowd_ecto/repo.ex
+++ b/lib/bitcrowd_ecto/repo.ex
@@ -15,7 +15,7 @@ defmodule BitcrowdEcto.Repo do
 
   @moduledoc since: "0.1.0"
 
-  import Ecto.Query, only: [from: 2, lock: 2, preload: 2, where: 3]
+  import Ecto.Query, only: [lock: 2, preload: 2, where: 3]
   alias Ecto.Adapters.SQL
 
   @type fetch_option ::
@@ -121,8 +121,8 @@ defmodule BitcrowdEcto.Repo do
       end
 
       @impl BER
-      def count(queryable) do
-        BER.count(__MODULE__, queryable)
+      def count(queryable, opts \\ []) do
+        BER.count(__MODULE__, queryable, opts)
       end
 
       @impl BER
@@ -153,7 +153,7 @@ defmodule BitcrowdEcto.Repo do
     |> where([], ^Enum.to_list(clauses))
     |> maybe_apply_lock(opts)
     |> maybe_preload(opts)
-    |> repo.one()
+    |> repo.one(opts)
     |> ok_tuple_or_not_found_error(Keyword.get(opts, :error_tag, queryable))
   end
 
@@ -185,11 +185,9 @@ defmodule BitcrowdEcto.Repo do
   defp ok_tuple_or_not_found_error(value, _error_tag), do: {:ok, value}
 
   @doc false
-  @spec count(module, Ecto.Queryable.t()) :: non_neg_integer
-  def count(repo, queryable) do
-    queryable
-    |> from(select: count())
-    |> repo.one!()
+  @spec count(module, Ecto.Queryable.t(), keyword) :: non_neg_integer
+  def count(repo, queryable, opts) do
+    repo.aggregate(queryable, :count, opts)
   end
 
   @doc false

--- a/lib/bitcrowd_ecto/repo.ex
+++ b/lib/bitcrowd_ecto/repo.ex
@@ -58,14 +58,6 @@ defmodule BitcrowdEcto.Repo do
 
   On error, a "tagged" error tuple is returned that contains the *original* queryable or module
   as the tag, e.g. `{:error, {:not_found, Account}}` for a `fetch_by(Account, id: 1)` call.
-
-  ## Additional options
-
-  * `prefix`             See https://hexdocs.pm/ecto/Ecto.Repo.html#c:one/2-options
-  * `timeout`            See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
-  * `log`                See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
-  * `telemetry_event`    See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
-  * `telemetry_options`  See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
   """
   @doc since: "0.1.0"
   @callback fetch_by(queryable :: Ecto.Queryable.t(), clauses :: map | keyword, [
@@ -82,6 +74,14 @@ defmodule BitcrowdEcto.Repo do
 
   * `lock`    any of `[:no_key_update, :update]` (defaults to `false`)
   * `preload` allows to preload associations
+
+  ## Additional options
+
+  * `prefix`             See https://hexdocs.pm/ecto/Ecto.Repo.html#c:one/2-options
+  * `timeout`            See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
+  * `log`                See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
+  * `telemetry_event`    See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
+  * `telemetry_options`  See [Ecto's Shared Options](https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options)
   """
   @doc since: "0.1.0"
   @callback count(queryable :: Ecto.Queryable.t()) :: non_neg_integer

--- a/test/bitcrowd_ecto/assertions_test.exs
+++ b/test/bitcrowd_ecto/assertions_test.exs
@@ -361,6 +361,20 @@ defmodule BitcrowdEcto.AssertionsTest do
         end)
       end
     end
+
+    test "accepts prefix option" do
+      prefix = "foo"
+
+      assert_count_difference(
+        TestRepo,
+        TestSchema,
+        2,
+        fn ->
+          insert_pair(:test_schema, [], prefix: prefix)
+        end,
+        prefix: prefix
+      )
+    end
   end
 
   describe "assert_count_differences/4" do
@@ -375,6 +389,19 @@ defmodule BitcrowdEcto.AssertionsTest do
           insert(:test_schema)
         end)
       end
+    end
+
+    test "accepts prefix option" do
+      prefix = "foo"
+
+      assert_count_differences(
+        TestRepo,
+        [{TestSchema, 2}],
+        fn ->
+          insert_pair(:test_schema, [], prefix: prefix)
+        end,
+        prefix: prefix
+      )
     end
   end
 

--- a/test/bitcrowd_ecto/assertions_test.exs
+++ b/test/bitcrowd_ecto/assertions_test.exs
@@ -348,7 +348,7 @@ defmodule BitcrowdEcto.AssertionsTest do
     end
   end
 
-  describe "assert_count_difference/4" do
+  describe "assert_count_difference/5" do
     test "asserts that a given function changes the count of a given database table" do
       assert_count_difference(TestRepo, TestSchema, 1, fn ->
         insert(:test_schema)

--- a/test/bitcrowd_ecto/repo_test.exs
+++ b/test/bitcrowd_ecto/repo_test.exs
@@ -8,7 +8,7 @@ defmodule BitcrowdEcto.RepoTest do
     %{resource: insert(:test_schema)}
   end
 
-  describe "count/1" do
+  describe "count/2" do
     setup [:insert_test_schema]
 
     test "it gives the count of the given queryable" do

--- a/test/bitcrowd_ecto/repo_test.exs
+++ b/test/bitcrowd_ecto/repo_test.exs
@@ -8,12 +8,26 @@ defmodule BitcrowdEcto.RepoTest do
     %{resource: insert(:test_schema)}
   end
 
-  describe "count/2" do
+  defp insert_test_schema_with_prefix(_) do
+    prefix = :foo
+    %{resource: insert(:test_schema, [], prefix: prefix), prefix: prefix}
+  end
+
+  describe "count/1" do
     setup [:insert_test_schema]
 
     test "it gives the count of the given queryable" do
       assert TestRepo.count(TestSchema) == 1
       assert TestRepo.count(from(x in TestSchema, where: is_nil(x.id))) == 0
+    end
+  end
+
+  describe "count/2" do
+    setup [:insert_test_schema_with_prefix]
+
+    test "it gives the count of the given queryable using a prefix option", %{prefix: prefix} do
+      assert TestRepo.count(TestSchema) == 0
+      assert TestRepo.count(TestSchema, prefix: prefix) == 1
     end
   end
 
@@ -58,6 +72,15 @@ defmodule BitcrowdEcto.RepoTest do
     end
   end
 
+  describe "fetch/3" do
+    setup [:insert_test_schema_with_prefix]
+
+    test "returns the record using the prefix option", %{resource: resource, prefix: prefix} do
+      assert TestRepo.fetch(TestSchema, resource.id) == {:error, {:not_found, TestSchema}}
+      assert TestRepo.fetch(TestSchema, resource.id, prefix: prefix) == {:ok, resource}
+    end
+  end
+
   describe "fetch_by/3" do
     setup [:insert_test_schema]
 
@@ -96,6 +119,20 @@ defmodule BitcrowdEcto.RepoTest do
     test "returns a tagged not found error" do
       assert TestRepo.fetch_by(TestSchema, id: Ecto.UUID.generate()) ==
                {:error, {:not_found, TestSchema}}
+    end
+  end
+
+  describe "fetch_by/3 accepts ecto options" do
+    setup [:insert_test_schema_with_prefix]
+
+    test "fetches a record by clauses and wraps it into an ok tuple", %{
+      resource: resource,
+      prefix: prefix
+    } do
+      assert TestRepo.fetch_by(TestSchema, id: resource.id) ==
+               {:error, {:not_found, TestSchema}}
+
+      assert TestRepo.fetch_by(TestSchema, [id: resource.id], prefix: prefix) == {:ok, resource}
     end
   end
 end

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -14,7 +14,13 @@ defmodule BitcrowdEcto.TestCase do
       import Ecto.Query
       import BitcrowdEcto.Factory
       import BitcrowdEcto.TestCase
-      alias BitcrowdEcto.{AlternativePrimaryKeyTestSchema, TestRepo, TestSchema}
+
+      alias BitcrowdEcto.{
+        AlternativePrimaryKeyTestSchema,
+        TestRepo,
+        TestSchema,
+        TestSchemaWithPrefix
+      }
     end
   end
 

--- a/test/support/test_repo/migrations/20230209214749_create_test_schema_with_prefix.exs
+++ b/test/support/test_repo/migrations/20230209214749_create_test_schema_with_prefix.exs
@@ -1,0 +1,24 @@
+defmodule BitcrowdEcto.TestRepo.Migrations.CreateTestSchemaWithPrefix do
+  use Ecto.Migration
+
+  def change do
+    prefix = "foo"
+    execute("CREATE SCHEMA IF NOT EXISTS #{prefix};", "DROP SCHEMA IF EXISTS #{prefix};")
+
+    create table(:test_schema, prefix: prefix) do
+      add(:some_string, :string)
+      add(:some_integer, :integer)
+      add(:some_boolean, :boolean)
+      add(:datetime, :utc_datetime_usec, null: true)
+      add(:from, :date, null: true)
+      add(:until, :date, null: true)
+      add(:from_dt, :utc_datetime_usec, null: true)
+      add(:until_dt, :utc_datetime_usec, null: true)
+      add(:from_number, :integer, null: true)
+      add(:to_number, :integer, null: true)
+      add(:money, :money_with_currency, null: true)
+
+      add(:parent_id, references(:test_schema), null: true)
+    end
+  end
+end


### PR DESCRIPTION
- Adds opts to the `repo.one` call within `Repo.fetch_by`
- Adds opts to signature and repo call of `Repo.count`
- Adds opts to signature and repo calls for `Assumptions.assert_count_difference`

Tests were not updated since the options are not used, just passed on to the Ecto function that already accepts options.