### PR TITLE
Handle missing schemas in ensure_up!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Allow any type of `id` param in `Repo.fetch/2`. Remove the (incorrect) guard restricting the `id` param to binaries, against the spec saying it would allow `any`.
+* Handle missing schemas gracefully in `Migrator.ensure_up!/0`.
 
 ## [0.16.0] - 2023-03-21
 


### PR DESCRIPTION
We noticed that `c:Migrator.ensure_up!/0` does not check for existence of schemas before calling `Ecto.Migrator.migrations/3`, which unfortunately terminates with a rather cryptic error.

This PR fixes that by explicitly checking schema existence before calling `migrations/3`. Opted for only checking (instead of creating it) to keep `ensure_up!/0`'s behaviour "read-only".

---

Unfortunately no test coverage as `Migrator` isn't tested at all, but I promise I've tested it locally.

![image](https://github.com/bitcrowd/bitcrowd_ecto/assets/96114/a0875926-dbd7-4df0-9945-4ff26fe6287c)

