### PR TITLE
Allow virtual fields and bump 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+# [1.1.1] - 2026-01-27
+
+### Fixed 
+
+* `flat_errors_on` works again on virtual fields
+
 ## [1.1.0] - 2026-01-07
 
 ### Added

--- a/lib/bitcrowd_ecto/assertions.ex
+++ b/lib/bitcrowd_ecto/assertions.ex
@@ -76,6 +76,7 @@ defmodule BitcrowdEcto.Assertions do
     fields_and_assocs_and_embeds =
       List.flatten([
         schema.__schema__(:fields),
+        schema.__schema__(:virtual_fields),
         schema.__schema__(:associations),
         schema.__schema__(:embeds)
       ])

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@
 defmodule BitcrowdEcto.MixProject do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.1.1"
 
   def project do
     [

--- a/test/bitcrowd_ecto/assertions_test.exs
+++ b/test/bitcrowd_ecto/assertions_test.exs
@@ -31,6 +31,12 @@ defmodule BitcrowdEcto.AssertionsTest do
       assert :bar in flat_errors_on(cs, :some_string, metadata: [:foo])
     end
 
+    test "works on virtual fields" do
+      cs = changeset() |> add_error(:some_virtual, "is wrong", validation: :wrong)
+
+      assert ["is wrong", :wrong] == flat_errors_on(cs, :some_virtual)
+    end
+
     test "fails when trying to list errors for a field/assoc/embed that does not exist" do
       assert_raise ExUnit.AssertionError, ~r/not a field/, fn ->
         assert flat_errors_on(changeset(), :doesnotexist)

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -33,6 +33,7 @@ defmodule BitcrowdEcto.TestSchema do
     field(:until_dt, :utc_datetime_usec)
     field(:from_number, :integer)
     field(:to_number, :integer)
+    field(:some_virtual, :string, virtual: true)
     field(:money, Money.Ecto.Composite.Type, default_currency: :EUR)
 
     belongs_to(:parent, __MODULE__)


### PR DESCRIPTION
With #58 we broke `flat_errors_on` for virtual fields, which should be a 100% ledgit use-case. 